### PR TITLE
Don't provide a password for sasl authentication

### DIFF
--- a/shelldap
+++ b/shelldap
@@ -770,7 +770,6 @@ You may try connecting insecurely, or install the module and try again.\n} if $@
 	#
 	if ( $sasl_conn ) {
 		$rv = $ldap->bind( $conf->{'binddn'},
-			password => $conf->{'bindpass'},
 			sasl     => $sasl_conn
 		);
 	}


### PR DESCRIPTION
When a sasl parameter is given (and used) the password parameter is not
used by Net::LDAP. If indeed a password is required it has to be passed
in the Authen::SASL object, not as parameter to bind.

So drop the password parameter which stops trying (and failing) to use
password authentication sometimes if in Net/LDAP.pm the iteration over
%ptype hits its 'password' member before the 'sasl' member.

Fixes: https://bugs.debian.org/941411
Fixes: https://github.com/mahlonsmith/shelldap/issues/2